### PR TITLE
CANMIO-SVO: Add selector for produced or consumed events.

### DIFF
--- a/generators/generate_CANMIO-SVO.sh
+++ b/generators/generate_CANMIO-SVO.sh
@@ -90,6 +90,22 @@ cat <<EOF
   ],
   "eventVariables": [
     {
+      "displayTitle": "Event Direction",
+      "type": "EventVariableSelect",
+      "eventVariableIndex": 3,
+      "bitMask": 128,
+      "options": [
+        {
+          "value": 0,
+          "label": "Consumed Event"
+        },
+        {
+          "value": 128,
+          "label": "Produced Event"
+        }
+      ]
+    },
+    {
       "displayTitle": "Consumed Event",
       "type": "EventVariableGroup",
       "visibilityLogic": {

--- a/work_in_progress/CANMIO-SVO-A532-4s.json
+++ b/work_in_progress/CANMIO-SVO-A532-4s.json
@@ -502,6 +502,22 @@
   ],
   "eventVariables": [
     {
+      "displayTitle": "Event Direction",
+      "type": "EventVariableSelect",
+      "eventVariableIndex": 3,
+      "bitMask": 128,
+      "options": [
+        {
+          "value": 0,
+          "label": "Consumed Event"
+        },
+        {
+          "value": 128,
+          "label": "Produced Event"
+        }
+      ]
+    },
+    {
       "displayTitle": "Consumed Event",
       "type": "EventVariableGroup",
       "visibilityLogic": {


### PR DESCRIPTION
As discussed we need a mechanism to switch between produced and consumed events.
Using a selector. This then makes one of the producer group and consumer group visible.