### PR TITLE
Addition of CANDISP v4C MDF

### DIFF
--- a/Status.md
+++ b/Status.md
@@ -31,6 +31,7 @@ the production directory.
 | CANCMDB-A553-4f.json    | In development                                       | Similar to CANCMD                               |
 | CANCSB-A537-4d.json     | RME UK                                               | Similar to CANCMD                               |
 | CANCSB-A537-4f.json     | RME UK                                               | Similar to CANCMD                               |
+| CANDISP-A53B-4C.json    | RME UK                                               | Development of CANLED64.                        |
 | CANDISP-A53B-4D.json    | RME UK                                               | Development of CANLED64. Tested by Stephen Wing |
 | CANGATE-A54B-1b.json    | RME UK                                               | Logic Module                                    |
 | CANGATEX-A56F-1f.json   | RME UK (with custom Arduino code)                    | Logic Module. Tested by Stephen Wing            |

--- a/Status.md
+++ b/Status.md
@@ -31,7 +31,7 @@ the production directory.
 | CANCMDB-A553-4f.json    | In development                                       | Similar to CANCMD                               |
 | CANCSB-A537-4d.json     | RME UK                                               | Similar to CANCMD                               |
 | CANCSB-A537-4f.json     | RME UK                                               | Similar to CANCMD                               |
-| CANDISP-A53B-4C.json    | RME UK                                               | Development of CANLED64.                        |
+| CANDISP-A53B-4C.json    | RME UK                                               | Development of CANLED64. Same as 4D             |
 | CANDISP-A53B-4D.json    | RME UK                                               | Development of CANLED64. Tested by Stephen Wing |
 | CANGATE-A54B-1b.json    | RME UK                                               | Logic Module                                    |
 | CANGATEX-A56F-1f.json   | RME UK (with custom Arduino code)                    | Logic Module. Tested by Stephen Wing            |

--- a/work_in_progress/MERG modules/CANDISP-A53B-4C.json
+++ b/work_in_progress/MERG modules/CANDISP-A53B-4C.json
@@ -1,0 +1,346 @@
+{
+  "timestamp": "202512261659",
+  "moduleName":"CANDISP",
+  "numberOfChannels": 64,
+  "channelNames": {
+    "1": "LED 1",
+    "2": "LED 2",
+    "3": "LED 3",
+    "4": "LED 4",
+    "5": "LED 5",
+    "6": "LED 6",
+    "7": "LED 7",
+    "8": "LED 8",
+    "9": "LED 9",
+    "10": "LED 10",
+    "11": "LED 11",
+    "12": "LED 12",
+    "13": "LED 13",
+    "14": "LED 14",
+    "15": "LED 15",
+    "16": "LED 16",
+    "17": "LED 17",
+    "18": "LED 18",
+    "19": "LED 19",
+    "20": "LED 20",
+    "21": "LED 21",
+    "22": "LED 22",
+    "23": "LED 23",
+    "24": "LED 24",
+    "25": "LED 25",
+    "26": "LED 26",
+    "27": "LED 27",
+    "28": "LED 28",
+    "29": "LED 29",
+    "30": "LED 30",
+    "31": "LED 31",
+    "32": "LED 32",
+    "33": "LED 33",
+    "34": "LED 34",
+    "35": "LED 35",
+    "36": "LED 36",
+    "37": "LED 37",
+    "38": "LED 38",
+    "39": "LED 39",
+    "40": "LED 40",
+    "41": "LED 41",
+    "42": "LED 42",
+    "43": "LED 43",
+    "44": "LED 44",
+    "45": "LED 45",
+    "46": "LED 46",
+    "47": "LED 47",
+    "48": "LED 48",
+    "49": "LED 49",
+    "50": "LED 50",
+    "51": "LED 51",
+    "52": "LED 52",
+    "53": "LED 53",
+    "54": "LED 54",
+    "55": "LED 55",
+    "56": "LED 56",
+    "57": "LED 57",
+    "58": "LED 58",
+    "59": "LED 59",
+    "60": "LED 60",
+    "61": "LED 61",
+    "62": "LED 62",
+    "63": "LED 63",
+    "64": "LED 64"
+  },
+  "nodeVariables": [],
+  "eventVariables": [
+    {
+      "type": "EventVariableSelect",
+      "eventVariableIndex": 17,
+      "displayTitle": "Select Event Action",
+      "options": [
+        {"label": "Normal", "value": 255},
+        {"label": "On only", "value": 254},
+        {"label": "Off Only", "value": 253},
+        {"label": "Flash", "value": 248}
+      ]
+    },
+    {
+      "type": "EventVariableTabs",
+      "tabPanels": [
+        { "displayTitle": "Leds 1-16",
+          "items": [
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 1,
+              "displayTitle": "Enable LEDs",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel1}"},
+                {"bitPosition": 1, "label": "${channel2}"},
+                {"bitPosition": 2, "label": "${channel3}"},
+                {"bitPosition": 3, "label": "${channel4}"},
+                {"bitPosition": 4, "label": "${channel5}"},
+                {"bitPosition": 5, "label": "${channel6}"},
+                {"bitPosition": 6, "label": "${channel7}"},
+                {"bitPosition": 7, "label": "${channel8}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 9,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel1}"},
+                {"bitPosition": 1, "label": "${channel2}"},
+                {"bitPosition": 2, "label": "${channel3}"},
+                {"bitPosition": 3, "label": "${channel4}"},
+                {"bitPosition": 4, "label": "${channel5}"},
+                {"bitPosition": 5, "label": "${channel6}"},
+                {"bitPosition": 6, "label": "${channel7}"},
+                {"bitPosition": 7, "label": "${channel8}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 2,
+              "displayTitle": "Enable Leds",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel9}"},
+                {"bitPosition": 1, "label": "${channel10}"},
+                {"bitPosition": 2, "label": "${channel11}"},
+                {"bitPosition": 3, "label": "${channel12}"},
+                {"bitPosition": 4, "label": "${channel13}"},
+                {"bitPosition": 5, "label": "${channel14}"},
+                {"bitPosition": 6, "label": "${channel15}"},
+                {"bitPosition": 7, "label": "${channel16}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 10,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel9}"},
+                {"bitPosition": 1, "label": "${channel10}"},
+                {"bitPosition": 2, "label": "${channel11}"},
+                {"bitPosition": 3, "label": "${channel12}"},
+                {"bitPosition": 4, "label": "${channel13}"},
+                {"bitPosition": 5, "label": "${channel14}"},
+                {"bitPosition": 6, "label": "${channel15}"},
+                {"bitPosition": 7, "label": "${channel16}"}
+              ]
+            }
+          ]
+        },
+        { "displayTitle": "Leds 17-32",
+          "items": [
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 3,
+              "displayTitle": "Enable LEDs",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel17}"},
+                {"bitPosition": 1, "label": "${channel18}"},
+                {"bitPosition": 2, "label": "${channel19}"},
+                {"bitPosition": 3, "label": "${channel20}"},
+                {"bitPosition": 4, "label": "${channel21}"},
+                {"bitPosition": 5, "label": "${channel22}"},
+                {"bitPosition": 6, "label": "${channel23}"},
+                {"bitPosition": 7, "label": "${channel24}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 11,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel17}"},
+                {"bitPosition": 1, "label": "${channel18}"},
+                {"bitPosition": 2, "label": "${channel19}"},
+                {"bitPosition": 3, "label": "${channel20}"},
+                {"bitPosition": 4, "label": "${channel21}"},
+                {"bitPosition": 5, "label": "${channel22}"},
+                {"bitPosition": 6, "label": "${channel23}"},
+                {"bitPosition": 7, "label": "${channel24}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 4,
+              "displayTitle": "Enable Leds",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel25}"},
+                {"bitPosition": 1, "label": "${channel26}"},
+                {"bitPosition": 2, "label": "${channel27}"},
+                {"bitPosition": 3, "label": "${channel28}"},
+                {"bitPosition": 4, "label": "${channel29}"},
+                {"bitPosition": 5, "label": "${channel30}"},
+                {"bitPosition": 6, "label": "${channel31}"},
+                {"bitPosition": 7, "label": "${channel32}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 12,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel25}"},
+                {"bitPosition": 1, "label": "${channel26}"},
+                {"bitPosition": 2, "label": "${channel27}"},
+                {"bitPosition": 3, "label": "${channel28}"},
+                {"bitPosition": 4, "label": "${channel29}"},
+                {"bitPosition": 5, "label": "${channel30}"},
+                {"bitPosition": 6, "label": "${channel31}"},
+                {"bitPosition": 7, "label": "${channel32}"}
+              ]
+            }
+          ]
+        },
+        { "displayTitle": "Leds 33-48",
+          "items": [
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 5,
+              "displayTitle": "Enable LEDs",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel33}"},
+                {"bitPosition": 1, "label": "${channel34}"},
+                {"bitPosition": 2, "label": "${channel35}"},
+                {"bitPosition": 3, "label": "${channel36}"},
+                {"bitPosition": 4, "label": "${channel37}"},
+                {"bitPosition": 5, "label": "${channel38}"},
+                {"bitPosition": 6, "label": "${channel39}"},
+                {"bitPosition": 7, "label": "${channel40}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 13,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel33}"},
+                {"bitPosition": 1, "label": "${channel34}"},
+                {"bitPosition": 2, "label": "${channel35}"},
+                {"bitPosition": 3, "label": "${channel36}"},
+                {"bitPosition": 4, "label": "${channel37}"},
+                {"bitPosition": 5, "label": "${channel38}"},
+                {"bitPosition": 6, "label": "${channel39}"},
+                {"bitPosition": 7, "label": "${channel40}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 6,
+              "displayTitle": "Enable Leds",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel41}"},
+                {"bitPosition": 1, "label": "${channel42}"},
+                {"bitPosition": 2, "label": "${channel43}"},
+                {"bitPosition": 3, "label": "${channel44}"},
+                {"bitPosition": 4, "label": "${channel45}"},
+                {"bitPosition": 5, "label": "${channel46}"},
+                {"bitPosition": 6, "label": "${channel47}"},
+                {"bitPosition": 7, "label": "${channel48}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 14,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel41}"},
+                {"bitPosition": 1, "label": "${channel42}"},
+                {"bitPosition": 2, "label": "${channel43}"},
+                {"bitPosition": 3, "label": "${channel44}"},
+                {"bitPosition": 4, "label": "${channel45}"},
+                {"bitPosition": 5, "label": "${channel46}"},
+                {"bitPosition": 6, "label": "${channel47}"},
+                {"bitPosition": 7, "label": "${channel48}"}
+              ]
+            }
+          ]
+        },
+        { "displayTitle": "Leds 49-64",
+          "items": [
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 7,
+              "displayTitle": "Enable LEDs",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel49}"},
+                {"bitPosition": 1, "label": "${channel50}"},
+                {"bitPosition": 2, "label": "${channel51}"},
+                {"bitPosition": 3, "label": "${channel52}"},
+                {"bitPosition": 4, "label": "${channel53}"},
+                {"bitPosition": 5, "label": "${channel54}"},
+                {"bitPosition": 6, "label": "${channel55}"},
+                {"bitPosition": 7, "label": "${channel56}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 15,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel49}"},
+                {"bitPosition": 1, "label": "${channel50}"},
+                {"bitPosition": 2, "label": "${channel51}"},
+                {"bitPosition": 3, "label": "${channel52}"},
+                {"bitPosition": 4, "label": "${channel53}"},
+                {"bitPosition": 5, "label": "${channel54}"},
+                {"bitPosition": 6, "label": "${channel55}"},
+                {"bitPosition": 7, "label": "${channel56}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 8,
+              "displayTitle": "Enable LEDs",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel57}"},
+                {"bitPosition": 1, "label": "${channel58}"},
+                {"bitPosition": 2, "label": "${channel59}"},
+                {"bitPosition": 3, "label": "${channel60}"},
+                {"bitPosition": 4, "label": "${channel61}"},
+                {"bitPosition": 5, "label": "${channel62}"},
+                {"bitPosition": 6, "label": "${channel63}"},
+                {"bitPosition": 7, "label": "${channel64}"}
+              ]
+            },
+            {
+              "type": "EventVariableBitArray",
+              "eventVariableIndex": 16,
+              "displayTitle": "Reverse polarity",
+              "bitCollection":[
+                {"bitPosition": 0, "label": "${channel57}"},
+                {"bitPosition": 1, "label": "${channel58}"},
+                {"bitPosition": 2, "label": "${channel59}"},
+                {"bitPosition": 3, "label": "${channel60}"},
+                {"bitPosition": 4, "label": "${channel61}"},
+                {"bitPosition": 5, "label": "${channel62}"},
+                {"bitPosition": 6, "label": "${channel63}"},
+                {"bitPosition": 7, "label": "${channel64}"}
+              ]
+            }
+          ]
+        }
+      ]        
+    }
+  ]
+}


### PR DESCRIPTION
Adding this additional MDF which is a copy of the 4D MDF. Both firmwares have the same NV/EV structure as the original CANLED64. This is untested by me, as I only have a v4D module.