### PR TITLE
CANGATEX Incorrect NVs for DN base value

### DIFF
--- a/work_in_progress/MERG modules/CANGATEX-A56F-1f.json
+++ b/work_in_progress/MERG modules/CANGATEX-A56F-1f.json
@@ -47,8 +47,8 @@
       "type": "NodeVariableDual",
       "displayTitle": "Base Value for DN",
       "displaySubTitle": "for short events",
-      "nodeVariableIndexHigh": 4,
-      "nodeVariableIndexLow": 5
+      "nodeVariableIndexHigh": 22,
+      "nodeVariableIndexLow": 23
     },   
     {
       "type": "NodeVariableGroup",

--- a/work_in_progress/MERG modules/CANGATEX-A56F-1g.json
+++ b/work_in_progress/MERG modules/CANGATEX-A56F-1g.json
@@ -53,8 +53,8 @@
       "type": "NodeVariableDual",
       "displayTitle": "Base Value for DN",
       "displaySubTitle": "for short events",
-      "nodeVariableIndexHigh": 4,
-      "nodeVariableIndexLow": 5
+      "nodeVariableIndexHigh": 22,
+      "nodeVariableIndexLow": 23
     },   
     {
       "type": "NodeVariableGroup",


### PR DESCRIPTION
The Base value for DN was listed as NVs 4 and 5, and should be 22 and 23.