### PR TITLE
CANGATEX update for EV3

### DIFF
--- a/work_in_progress/MERG modules/CANGATEX-A56F-1f.json
+++ b/work_in_progress/MERG modules/CANGATEX-A56F-1f.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "202601261554",
+  "timestamp": "202603191554",
   "moduleName":"CANGATEX",
   "nodeVariables": [
     {
@@ -170,16 +170,15 @@
       "type": "EventVariableDual"
     },
     {
+      "displayTitle": "Invert Gate Polarity",
+      "displaySubTitle": "0 = Normal, anything else will invert",
+      "eventVariableIndex": 3,
+      "type": "EventVariableNumber"
+    },
+    {
       "displayTitle": "No Longer Used",
       "type": "EventVariableGroup",
       "groupItems": [
-        {
-          "displayTitle": "Invert Gate Polarity",
-          "displaySubTitle": "Not needed",
-          "eventVariableIndex": 3,
-          "bit": 0,
-          "type": "EventVariableBitSingle"
-        },
         {
           "displayTitle": "Gate Number",
           "displaySubTitle": "Not used on CANGATEX",

--- a/work_in_progress/MERG modules/CANGATEX-A56F-1g.json
+++ b/work_in_progress/MERG modules/CANGATEX-A56F-1g.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "202601261554",
+  "timestamp": "202603191554",
   "moduleName":"CANGATEX",
   "nodeVariables": [
     {
@@ -176,16 +176,15 @@
       "type": "EventVariableDual"
     },
     {
+      "displayTitle": "Invert Gate Polarity",
+      "displaySubTitle": "0 = Normal, anything else will invert",
+      "eventVariableIndex": 3,
+      "type": "EventVariableNumber"
+    },
+    {
       "displayTitle": "No Longer Used",
       "type": "EventVariableGroup",
       "groupItems": [
-        {
-          "displayTitle": "Invert Gate Polarity",
-          "displaySubTitle": "Not needed",
-          "eventVariableIndex": 3,
-          "bit": 0,
-          "type": "EventVariableBitSingle"
-        },
         {
           "displayTitle": "Gate Number",
           "displaySubTitle": "Not used on CANGATEX",


### PR DESCRIPTION
EV3 is no longer a tickbox, as the code is checking for a non-zero value, and if the Arduino has preset the EEPROM value to 255, toggling bit 0 changes the value to 254, which still results in the invert option occurring.

Also removed the setting from the "No Longer Used" event group as the code will still allow for this setting.