### PR TITLE
CANGATEXL 2a EV3 update

### DIFF
--- a/work_in_progress/MERG modules/CANGATEX-A559-2a.json
+++ b/work_in_progress/MERG modules/CANGATEX-A559-2a.json
@@ -181,13 +181,7 @@
       "displayTitle": "Input/Output Gate Polarity",
       "bitCollection":[
         {"bitPosition": 0, "label": "Invert Output"},
-        {"bitPosition": 1, "label": "Invert Input"},
-        {"bitPosition": 2, "label": "n/a"},
-        {"bitPosition": 3, "label": "n/a"},
-        {"bitPosition": 4, "label": "n/a"},
-        {"bitPosition": 5, "label": "n/a"},
-        {"bitPosition": 6, "label": "n/a"},
-        {"bitPosition": 7, "label": "n/a"}
+        {"bitPosition": 1, "label": "Invert Input"}
       ]
     },
     {

--- a/work_in_progress/MERG modules/CANGATEXL-A55A-2a.json
+++ b/work_in_progress/MERG modules/CANGATEXL-A55A-2a.json
@@ -180,16 +180,24 @@
       "type": "EventVariableDual"
     },
     {
+      "type": "EventVariableBitArray",
+      "eventVariableIndex": 3,
+      "displayTitle": "Input/Output Gate Polarity",
+      "bitCollection":[
+        {"bitPosition": 0, "label": "Invert Output"},
+        {"bitPosition": 1, "label": "Invert Input"},
+        {"bitPosition": 2, "label": "n/a"},
+        {"bitPosition": 3, "label": "n/a"},
+        {"bitPosition": 4, "label": "n/a"},
+        {"bitPosition": 5, "label": "n/a"},
+        {"bitPosition": 6, "label": "n/a"},
+        {"bitPosition": 7, "label": "n/a"}
+      ]
+    },
+    {
       "displayTitle": "No Longer Used",
       "type": "EventVariableGroup",
       "groupItems": [
-        {
-          "displayTitle": "Invert Gate Polarity",
-          "displaySubTitle": "Not needed",
-          "eventVariableIndex": 3,
-          "bit": 0,
-          "type": "EventVariableBitSingle"
-        },
         {
           "displayTitle": "Gate Number",
           "displaySubTitle": "Not used on CANGATEX",

--- a/work_in_progress/MERG modules/CANGATEXL-A55A-2a.json
+++ b/work_in_progress/MERG modules/CANGATEXL-A55A-2a.json
@@ -185,13 +185,7 @@
       "displayTitle": "Input/Output Gate Polarity",
       "bitCollection":[
         {"bitPosition": 0, "label": "Invert Output"},
-        {"bitPosition": 1, "label": "Invert Input"},
-        {"bitPosition": 2, "label": "n/a"},
-        {"bitPosition": 3, "label": "n/a"},
-        {"bitPosition": 4, "label": "n/a"},
-        {"bitPosition": 5, "label": "n/a"},
-        {"bitPosition": 6, "label": "n/a"},
-        {"bitPosition": 7, "label": "n/a"}
+        {"bitPosition": 1, "label": "Invert Input"}
       ]
     },
     {


### PR DESCRIPTION
The new CANGATEXL file was missing the bitwise options for EV3 introduced with the new 2a firmware. The MDF worked, but now allows the user to select individual bits.